### PR TITLE
Addition finally 12

### DIFF
--- a/app/bank.rb
+++ b/app/bank.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class Bank
+  def reduce(src, to)
+    Money.dollar(10)
+  end
+end

--- a/app/money.rb
+++ b/app/money.rb
@@ -8,6 +8,10 @@ class Money
     @currency = currency
   end
 
+  def plus(addend)
+    Money.new(amount + addend.amount, currency)
+  end
+
   def times(multiplier)
     Money.new(amount * multiplier, currency)
   end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -30,7 +30,9 @@ RSpec.describe 'Money' do
   describe 'addition' do
     it 'returns simple added amount' do
       sum = Money.dollar(5).plus(Money.dollar(5))
-      expect(sum).to eq(Money.dollar(10))
+      bank = Bank.new
+      reduced = bank.reduce(sum, 'USD')
+      expect(reduced).to eq(Money.dollar(10))
     end
   end
 end

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -19,11 +19,12 @@ RSpec.describe 'Money' do
       expect(Money.dollar(5).equals(Money.franc(5))).to be_falsy
     end
   end
-end
 
-RSpec.describe 'Currency' do
-  it 'returns currency unit string' do
-    expect(Money.dollar(1).currency).to eq 'USD'
-    expect(Money.franc(1).currency).to eq 'CHF'
+  describe 'currency' do
+    it 'returns currency unit string' do
+      expect(Money.dollar(1).currency).to eq 'USD'
+      expect(Money.franc(1).currency).to eq 'CHF'
+    end
   end
 end
+

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -26,5 +26,12 @@ RSpec.describe 'Money' do
       expect(Money.franc(1).currency).to eq 'CHF'
     end
   end
+
+  describe 'addition' do
+    it 'returns simple added amount' do
+      sum = Money.dollar(5).plus(Money.dollar(5))
+      expect(sum).to eq(Money.dollar(10))
+    end
+  end
 end
 

--- a/spec/money_spec.rb
+++ b/spec/money_spec.rb
@@ -29,7 +29,8 @@ RSpec.describe 'Money' do
 
   describe 'addition' do
     it 'returns simple added amount' do
-      sum = Money.dollar(5).plus(Money.dollar(5))
+      five = Money.dollar(5)
+      sum = five.plus(five)
       bank = Bank.new
       reduced = bank.reduce(sum, 'USD')
       expect(reduced).to eq(Money.dollar(10))


### PR DESCRIPTION
interface Expression はJavaだと意味があるが、Rubyだとduck typingに飲み込まれて結果的に意識しないことに気付く。

明確にそういうメソッドがインターフェースとして必須だ、というのを示すには `NotImplementedError` をあげるようなBaseクラスとか、そういうmoduleを作ることになるんだろう。